### PR TITLE
Added some missing build-deps, fixed checking lib deps on oneiric. Fixed compilation failure with gcc 4.6

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,7 +45,7 @@ OPENMAX_OPTIONS = --enable-openmax
 endif
 
 # Various environment variables to set
-ENV_OPTIONS = CFLAGS="$(DEB_CFLAGS)" CXXFLAGS="$(DEB_CXXFLAGS)"
+ENV_OPTIONS = CFLAGS="$(DEB_CFLAGS)" CXXFLAGS="-fpermissive $(DEB_CXXFLAGS)"
 
 # List of options to pass to configure. Can be overridden.
 # Extra options can simply be passed using XBMC_CONFIG_EXTRA_OPTIONS env

--- a/debian/var_info
+++ b/debian/var_info
@@ -12,6 +12,7 @@ BUILD_DEPENDS="debhelper (>= 7.0.50~),
  unzip,
  libboost-dev,
  zip,
+ libudev-dev | libusb-dev,
  libtool,
  libgles2-mesa-dev [armel] | libgl1-mesa-dev | libgl-dev,
  libglu1-mesa-dev | libglu-dev,
@@ -110,7 +111,7 @@ case "$1" in
         printf "$BUILD_DEPENDS"
         ;;
     LIBCURL_DEPENDS)
-        LIBCURL_DEPENDS=$(cat /var/lib/dpkg/info/libcurl3-gnutls.shlibs | \
+        LIBCURL_DEPENDS=$(cat /var/lib/dpkg/info/libcurl3-gnutls*.shlibs | \
           sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
         printf "$LIBCURL_DEPENDS"
         ;;
@@ -150,7 +151,7 @@ case "$1" in
         printf "$LIBVDPAU_DEPENDS"
         ;;
     LIBRTMP_DEPENDS)
-        LIBRTMP_DEPENDS=$(cat /var/lib/dpkg/info/librtmp0.shlibs | \
+        LIBRTMP_DEPENDS=$(cat /var/lib/dpkg/info/librtmp0*.shlibs | \
           sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
         printf "$LIBRTMP_DEPENDS"
         ;;


### PR DESCRIPTION
Updated build-deps (libudev-dev | libusb-dev), fixed checking libcurl & librtmp deps on oneiric. Add -fpermissive to CXXFLAGS to compile with gcc 4.6
