### PR TITLE
Two dependency fixes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -147,3 +147,5 @@ override_dh_gencontrol:
 		-i "debian/xbmc-bin/DEBIAN/control"
 	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBRTMP_DEPENDS)/" \
 		-i "debian/xbmc-bin/DEBIAN/control"
+	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBCEC_DEPENDS)/" \
+		-i "debian/xbmc-bin/DEBIAN/control"

--- a/debian/var_info
+++ b/debian/var_info
@@ -166,6 +166,11 @@ case "$1" in
           sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
         printf "$LIBRTMP_DEPENDS"
         ;;
+    LIBCEC_DEPENDS)
+        LIBCEC_DEPENDS=$(cat /var/lib/dpkg/info/libcec*.shlibs | \
+          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
+        printf "$LIBCEC_DEPENDS"
+        ;;
 esac
 
 exit 0


### PR DESCRIPTION
Hello,
I came up with these patches while building my local packages on Ubuntu Oneiric amd64:
- dependency generation against dlopened libraries in debian/var_info needed to be fixed for multi-arch libs (/var/lib/dpkg/info/libfoo:amd64.shlibs);
- recently added compilation against libcec needs it's own dependency generation in debian/var_info (libcec.so is dlopened in function LibCecInit()).

I hope that you will find my changes useful.
