### PR TITLE
Rework dependency generation against dlopened libs.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -142,6 +142,7 @@ Package: xbmc-bin
 Architecture: i386 amd64 powerpc ppc64 armel
 Depends: ${shlibs:Depends},
          ${misc:Depends}
+Recommends: ${shlibs:Recommends}
 Provides: xbmc-common, xbmc-eventclients-wiiremote
 Replaces: xbmc-common, xbmc-eventclients-wiiremote
 Conflicts: xbmc-common, xbmc-eventclients-wiiremote

--- a/debian/control.in
+++ b/debian/control.in
@@ -59,6 +59,7 @@ Package: xbmc-bin
 Architecture: i386 amd64 powerpc ppc64 armel
 Depends: ${shlibs:Depends},
          ${misc:Depends}
+Recommends: ${shlibs:Recommends}
 Provides: xbmc-common, xbmc-eventclients-wiiremote
 Replaces: xbmc-common, xbmc-eventclients-wiiremote
 Conflicts: xbmc-common, xbmc-eventclients-wiiremote

--- a/debian/rules
+++ b/debian/rules
@@ -98,7 +98,6 @@ DH_PARALLEL_OPT=$(shell dh_testdir --parallel 2>/dev/null && echo "--parallel")
 	@echo "Generating $$(echo $@ | sed 's/\.in$$//') from $@"
 	perl -p \
 	-e 's{#BUILD_DEPENDS#}{qx(sh debian/var_info BUILD_DEPENDS)}ge;' \
-	-e 's{#LIBCURL_DEPENDS#}{qx(sh debian/var_info LIBCURL_DEPENDS)}ge;' \
 	-e 's{#XBMC_LIVE_DEPENDS#}{qx(sh debian/var_info XBMC_LIVE_DEPENDS)}ge;' \
 	< $@ > $$(echo $@ | sed 's/\.in$$//')
 
@@ -134,18 +133,16 @@ override_dh_makeshlibs:
 	# We don't install shared libraries in standard locations so don't run
 	# dh_makeshlibs
 
-override_dh_shlibdeps:
+override_dh_shlibdeps: debian/tmp/xbmc-bin-dummy.so
 	dh_shlibdeps -a -O--parallel \
 		-l$(CURDIR)/debian/xbmc-bin/usr/lib/xbmc/system/players/dvdplayer
-
-override_dh_gencontrol:
-	dh_gencontrol
 	# Need to manually add dependencies for dlopened libs.
-	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBCURL_DEPENDS)/" \
-		-i "debian/xbmc-bin/DEBIAN/control"
-	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBVDPAU_DEPENDS)/" \
-		-i "debian/xbmc-bin/DEBIAN/control"
-	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBRTMP_DEPENDS)/" \
-		-i "debian/xbmc-bin/DEBIAN/control"
-	sed "s/^Depends:.*$$/&, $$(sh debian/var_info LIBCEC_DEPENDS)/" \
-		-i "debian/xbmc-bin/DEBIAN/control"
+	dpkg-shlibdeps -dRecommends -edebian/tmp/xbmc-bin-dummy.so -xlibc6 -O >>debian/xbmc-bin.substvars
+
+debian/tmp/xbmc-bin-dummy.so:
+	mkdir -p debian/tmp
+	cc -xc -shared -Wl,--no-as-needed -o $@ /dev/null \
+		-lcurl-gnutls \
+		-lvdpau \
+		-lrtmp \
+		-lcec

--- a/debian/var_info
+++ b/debian/var_info
@@ -114,11 +114,6 @@ case "$1" in
     BUILD_DEPENDS)
         printf "$BUILD_DEPENDS"
         ;;
-    LIBCURL_DEPENDS)
-        LIBCURL_DEPENDS=$(cat /var/lib/dpkg/info/libcurl3-gnutls*.shlibs | \
-          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
-        printf "$LIBCURL_DEPENDS"
-        ;;
     XBMC_LIVE_DEPENDS)
         XBMC_LIVE_DEPENDS="xbmc (= \${binary:Version}),
          openssh-server,
@@ -143,33 +138,6 @@ case "$1" in
         fi
 
         printf "$XBMC_LIVE_DEPENDS"
-        ;;
-    LIBVDPAU_DEPENDS)
-        LIBVDPAU_DEPENDS=""
-        if [ -r /var/lib/dpkg/info/libvdpau*.shlibs ]; then
-          LIBVDPAU_DEPENDS=$(cat /var/lib/dpkg/info/libvdpau*.shlibs | \
-          grep 'libvdpau ' | \
-          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
-        elif [ -r /var/lib/dpkg/info/nvidia-185-libvdpau.shlibs ]; then
-          LIBVDPAU_DEPENDS=$(cat /var/lib/dpkg/info/nvidia-185-libvdpau.shlibs | \
-          grep 'libvdpau ' | \
-          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
-        fi
-        if [ -z $LIBVDPAU_DEPENDS ]; then
-          echo "Error in getting shlibs information for libvdpau."
-          exit 1
-        fi
-        printf "$LIBVDPAU_DEPENDS"
-        ;;
-    LIBRTMP_DEPENDS)
-        LIBRTMP_DEPENDS=$(cat /var/lib/dpkg/info/librtmp0*.shlibs | \
-          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
-        printf "$LIBRTMP_DEPENDS"
-        ;;
-    LIBCEC_DEPENDS)
-        LIBCEC_DEPENDS=$(cat /var/lib/dpkg/info/libcec*.shlibs | \
-          sed 's/^[^[:space:]]\+\?[[:space:]]\+\?[^[:space:]]\+\?[[:space:]]\+\?\(.*\)$/\1/')
-        printf "$LIBCEC_DEPENDS"
         ;;
 esac
 


### PR DESCRIPTION
A proposal of a more generic way for generating package dependencies against external plugin libraries.

Using Recommends field instead of Depends seems more compliant with the Debian policy:
<cite>
<b>Recommends</b> This declares a strong, but not absolute, dependency.
The Recommends field should list packages that would be found together with this one in all but unusual installations.
</cite>
