### PR TITLE
Add new package "xbmc-dev-tools" containing TexturePacker for skinners.

### DIFF
--- a/control.in
+++ b/control.in
@@ -75,6 +75,30 @@ Description: XBMC Media Center (binary data package)
  .
  This package contains all the binary data needed to have a working XBMC.
 
+Package: xbmc-dev-tools
+Architecture: all
+Depends: ${misc:Depends}
+Description: XBMC Media Center (developer tools)
+ XBMC, recursive acronym for "XBMC Media Center", is an award winning free and
+ open source software media-player and entertainment hub for all your digital
+ media. XBMC is available for Linux, Mac OS X (Leopard, Tiger and Apple TV)
+ and Microsoft Windows, as well as the original Xbox game console. Created in
+ 2003 by a group of like minded programmers, XBMC is a non-profit project run
+ and developed by volunteers located around the world. More than 50 software
+ developers have contributed to XBMC, and 100-plus translators have worked to
+ expand its reach, making it available in more than 30 languages.
+ .
+ While XBMC functions very well as a standard media player application for
+ your computer, it has been designed to be the perfect companion for your
+ HTPC. Supporting an almost endless range of remote controls, and combined
+ with its beautiful interface and powerful skinning engine, XBMC feels very
+ natural to use from the couch and is the ideal solution for your home
+ theater. Once installed, your computer will become a fully functional
+ multimedia jukebox.
+ .
+ This package contains the following developer tools:
+ - Texture packer.
+
 Package: xbmc-eventclients-common
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}

--- a/control.in
+++ b/control.in
@@ -76,8 +76,10 @@ Description: XBMC Media Center (binary data package)
  This package contains all the binary data needed to have a working XBMC.
 
 Package: xbmc-dev-tools
-Architecture: all
-Depends: ${misc:Depends}
+Architecture: i386 amd64 armhf
+Depends: ${misc:Depends},
+         liblzo2-2,
+         libsdl-image1.2
 Description: XBMC Media Center (developer tools)
  XBMC, recursive acronym for "XBMC Media Center", is an award winning free and
  open source software media-player and entertainment hub for all your digital

--- a/debian/xbmc-dev-tools.install
+++ b/debian/xbmc-dev-tools.install
@@ -1,0 +1,1 @@
+../../tools/TexturePacker/TexturePacker usr/share/xbmc/tools


### PR DESCRIPTION
While modifying default skin I realized that you have to use TexturePacker to repack media images.

However to use TexturePacker you have to compile XBMC. While I am fine with this, it did take a long time for what it really needs to be.

I also came across this thread, where a guy wanted to create a skin, but gave up because he couldn't compile XBMC to get TexturePacker.
http://forum.xbmc.org/showthread.php?pid=604845%23pid604845

I believe that if someone wants to create or modify XBMC skin, they don't necessarily need to be able to compile XBMC, and a compiled windows binary seems to be included anyway.

Since TexturePacker is compiled while building XBMC debian package, I though that it might be useful to create a separate package with TexturePacker.

The changes proposed in pull request achieve this with new package "xbmc-dev-tools". 
