### PR TITLE
rules: fix setting XBMC_RELEASE.

### DIFF
--- a/rules.distro
+++ b/rules.distro
@@ -11,7 +11,7 @@ DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 # NOTE: DEB_BUILD_OPTIONS must have 'nostrip' otherwise debugging symbols will
 # be stripped from binaries.
 XBMC_RELEASE ?= yes
-ifneq (,$(findstring nostrip,$(DEB_BUILD_OPTIONS)))
+ifneq (nostrip,$(findstring nostrip,$(DEB_BUILD_OPTIONS)))
 XBMC_RELEASE ?= no
 endif
 

--- a/rules.ppa
+++ b/rules.ppa
@@ -11,7 +11,7 @@ DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 # NOTE: DEB_BUILD_OPTIONS must have 'nostrip' otherwise debugging symbols will
 # be stripped from binaries.
 XBMC_RELEASE ?= yes
-ifneq (,$(findstring nostrip,$(DEB_BUILD_OPTIONS)))
+ifneq (nostrip,$(findstring nostrip,$(DEB_BUILD_OPTIONS)))
 XBMC_RELEASE ?= no
 endif
 


### PR DESCRIPTION
The logic for setting XBMC_RELEASE based on DEB_BUILD_OPTIONS has been reversed.
