### PR TITLE
fix build error on ubuntu 21.04

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,10 +6,10 @@ DEB_HOST_GNU_TYPE   ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_GNU_TYPE  ?= $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
-#export DEB_CFLAGS_MAINT_STRIP  = -O2
-#export DEB_CFLAGS_MAINT_APPEND  = -O3
-#export DEB_CXXFLAGS_MAINT_STRIP  = -O2
-#export DEB_CXXFLAGS_MAINT_APPEND  = -O3
+export DEB_CFLAGS_MAINT_STRIP  = -flto=auto -ffat-lto-objects
+export DEB_CFLAGS_MAINT_APPEND  = -O3
+export DEB_CXXFLAGS_MAINT_STRIP  = -flto=auto -ffat-lto-objects
+export DEB_CXXFLAGS_MAINT_APPEND  = -O3
 
 USE_LTO ?= yes
 


### PR DESCRIPTION
strip default LTO flags, we have our own lto support