### PR TITLE
[BACKPORT]Install KodiConfig.cmake to arch-specific path

### DIFF
--- a/debian/kodi-addon-dev.install
+++ b/debian/kodi-addon-dev.install
@@ -4,4 +4,5 @@ usr/include/kodi/gui
 usr/include/kodi/tools
 usr/include/kodi/platform
 usr/include/kodi/addon-instance
+usr/lib/*/kodi/cmake
 usr/share/kodi/cmake/*.cmake


### PR DESCRIPTION
Hugh Cole-Baker reported the issue with incorrect placement of
KodiConfig.cmake (that contains architecture-dependent paths)
into arch-independent /usr/share/kodi/cmake as Debian Bug #999482:
https://bugs.debian.org/999482

This fix must be merged after the corresponding xbmc/xbmc PRs
for Nexus and Matrix.

Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>
